### PR TITLE
feat: refresh docs site with minimal markdown theme

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,165 +1,82 @@
 <!DOCTYPE html>
-<html data-color-mode="light" data-dark-theme="dark" data-light-theme="light" lang="zh-CN">
+<html lang="zh-CN">
 <head>
-    <meta content="text/html; charset=utf-8" http-equiv="content-type" />
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link href='https://mirrors.sustech.edu.cn/cdnjs/ajax/libs/Primer/21.0.7/primer.css' rel='stylesheet' />
-    
-    <link rel="icon" href="https://github.githubassets.com/favicons/favicon.svg"><script>
-        let theme = localStorage.getItem("meek_theme") || "light";
-        document.documentElement.setAttribute("data-color-mode", theme);
-    </script>
-<meta name="description" content="3年创始人IP摄影师 INTJ 射手座 分享个人成长、项目实战赚钱日记、天赋优势、海外项目信息差、 健身ing">
-<meta property="og:title" content="硬核水墨">
-<meta property="og:description" content="3年创始人IP摄影师 INTJ 射手座 分享个人成长、项目实战赚钱日记、天赋优势、海外项目信息差、 健身ing">
-<meta property="og:type" content="blog">
-<meta property="og:url" content="https://hacksmo.github.io">
-<meta property="og:image" content="https://github.githubassets.com/favicons/favicon.svg">
-<title>硬核水墨</title>
-
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>硬核水墨 · Markdown 笔记</title>
+  <meta name="description" content="硬核水墨的原创 Markdown 文章与项目记录，简洁、专注、持续更新。">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
 </head>
-<style>
-body{box-sizing: border-box;min-width: 200px;max-width: 900px;margin: 20px auto;padding: 45px;font-size: 16px;font-family: sans-serif;line-height: 1.25;}
-#header{display:flex;padding-bottom:8px;border-bottom: 1px solid var(--borderColor-muted, var(--color-border-muted));margin-bottom: 16px;}
-#footer {margin-top:64px; text-align: center;font-size: small;}
-
-</style>
-
-<style>
-.avatar {transition: 0.8s;width:64px;height:64px;object-fit: cover;}
-.avatar:hover{transform: scale(1.15) rotate(360deg);}
-#header h1 a{color:inherit;text-decoration:none;vertical-align: bottom;font-size:40px;font-family:Monaco;margin-left:8px;}
-.title-right{display:flex;margin:auto 0 0 auto;}
-.title-right button{margin-right:8px;padding:16px;}
-.title-right .circle{padding: 14px 16px;}
-
-.SideNav{min-width: 360px;}
-.SideNav-icon{margin-right: 16px}
-.SideNav-item .Label{color: #fff;margin-left:4px;}
-.d-flex{min-width:0;}
-.listTitle{overflow:hidden;white-space:nowrap;text-overflow: ellipsis;max-width: 100%;}
-.listLabels{white-space:nowrap;display:flex;}
-.listLabels object{max-height:16px;max-width:24px;}
-
-@media (max-width: 600px) {
-    body {padding: 8px;}
-    .avatar {width:40px;height:40px;}
-    .blogTitle{display:none;}
-    #buttonRSS{display:none;}
-    .LabelTime{display:none;}
-}
-</style>
-
-
-
 <body>
-    <div id="header">
-<h1>
-    <img src="https://github.githubassets.com/favicons/favicon.svg" class="avatar circle" id="avatarImg" alt="avatar"><a class="blogTitle">硬核水墨</a></h1>
-<div class="title-right">
-    <a href="https://hacksmo.github.io/tag.html" id="buttonSearch" class="btn btn-invisible circle" title="搜索">
-        <svg class="octicon" width="16" height="16" >
-            <path id="pathSearch" fill-rule="evenodd"></path>
-        </svg>
-    </a>
-    
-    
-    <a href="https://hacksmo.github.io/rss.xml" target="_blank" id="buttonRSS" class="btn btn-invisible circle" title="RSS">
-        <svg class="octicon" width="16" height="16" >
-            <path id="pathRSS" fill-rule="evenodd"></path>
-        </svg>
-    </a>
-    <a class="btn btn-invisible circle" onclick="modeSwitch()" title="切换主题">
-        <svg class="octicon" width="16" height="16" >
-            <path id="themeSwitch" fill-rule="evenodd"></path>
-        </svg>
-    </a>
-</div>
-</div>
-    <div id="content">
-<div style="margin-bottom: 16px;">3年创始人IP摄影师 INTJ 射手座 分享个人成长、项目实战赚钱日记、天赋优势、海外项目信息差、 健身ing</div>
-<nav class="SideNav border">
-<a class="SideNav-item d-flex flex-items-center flex-justify-between" href="post/pu-tong-ren-bu-shi-he-zuo-xiao-lv-shu.html">
-    <div class="d-flex flex-items-center">
-        <svg class="SideNav-icon octicon" style="witdh:16px;height:16px"><path class="svgTop0" d=""></path>
-        </svg>
-        <span class="listTitle">普通人不适合做小绿书</span>
-    </div>
-    <div class="listLabels">
-        
-        <span class="Label LabelName" style="background-color:#0075ca"><object><a style="color:#fff" href="tag.html#documentation">documentation</a></object></span>
-        <span class="Label LabelTime" style="background-color:#bc4c00">2024-11-12</span>
-    </div>
-</a>
-</nav>
-</div>
-    <div id="footer"><div id="footer1">Copyright © <span id="copyrightYear"></span> <a href="https://hacksmo.github.io">硬核水墨</a></div>
-<div id="footer2">
-    <span id="runday"></span><span>Powered by <a href="https://meekdai.com/Gmeek.html" target="_blank">Gmeek</a></span>
-</div>
+  <div class="container">
+    <header class="site-header">
+      <h1 class="site-title">硬核水墨</h1>
+      <p class="site-description">记录个人成长、项目实战与灵感碎片。所有内容均以 Markdown 撰写，专注于思考与价值沉淀。</p>
+      <nav class="site-links" aria-label="站点导航">
+        <a href="tag.html">浏览标签</a>
+        <a href="rss.xml">RSS 订阅</a>
+      </nav>
+    </header>
 
-<script>
-var now=new Date();
-document.getElementById("copyrightYear").innerHTML=now.getFullYear();
+    <main>
+      <section class="post-list" id="postList" aria-live="polite"></section>
+    </main>
 
-if(""!=""){
-    var startSite=new Date("");
-    var diff=now.getTime()-startSite.getTime();
-    var diffDay=Math.floor(diff/(1000*60*60*24));
-    document.getElementById("runday").innerHTML="网站运行"+diffDay+"天"+" • ";
-}
-</script></div>
+    <footer class="site-footer">
+      <p>© <span id="year"></span> 硬核水墨 · 由 Markdown 驱动</p>
+    </footer>
+  </div>
+
+  <script>
+    const postListElement = document.getElementById('postList');
+    const currentYear = new Date().getFullYear();
+    document.getElementById('year').textContent = currentYear;
+
+    fetch('postList.json')
+      .then((response) => response.json())
+      .then((data) => {
+        const posts = Object.values(data)
+          .filter((item) => item && item.postUrl)
+          .sort((a, b) => new Date(b.createdDate) - new Date(a.createdDate));
+
+        if (posts.length === 0) {
+          postListElement.innerHTML = '<p style="color: var(--muted);">正在创作新的文章，敬请期待。</p>';
+          return;
+        }
+
+        for (const post of posts) {
+          const article = document.createElement('article');
+          article.className = 'post-card';
+
+          const date = new Date(`${post.createdDate}T00:00:00`);
+          const formattedDate = date.toLocaleDateString('zh-CN', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric'
+          });
+
+          const tagChips = (post.labels || [])
+            .map((label) => `<span class="tag-chip">${label}</span>`)
+            .join('');
+
+          const tagsMarkup = tagChips ? `<div class="tags">${tagChips}</div>` : '';
+
+          article.innerHTML = `
+            <time datetime="${post.createdDate}">${formattedDate}</time>
+            <h2><a href="${post.postUrl}">${post.postTitle}</a></h2>
+            <p>来自 Markdown 的长文创作记录，点击继续阅读。</p>
+            ${tagsMarkup}
+          `;
+
+          postListElement.appendChild(article);
+        }
+      })
+      .catch(() => {
+        postListElement.innerHTML = '<p style="color: var(--muted);">暂时无法加载文章列表，请稍后再试。</p>';
+      });
+  </script>
 </body>
-<script>
-var IconList={'sun': 'M8 10.5a2.5 2.5 0 100-5 2.5 2.5 0 000 5zM8 12a4 4 0 100-8 4 4 0 000 8zM8 0a.75.75 0 01.75.75v1.5a.75.75 0 01-1.5 0V.75A.75.75 0 018 0zm0 13a.75.75 0 01.75.75v1.5a.75.75 0 01-1.5 0v-1.5A.75.75 0 018 13zM2.343 2.343a.75.75 0 011.061 0l1.06 1.061a.75.75 0 01-1.06 1.06l-1.06-1.06a.75.75 0 010-1.06zm9.193 9.193a.75.75 0 011.06 0l1.061 1.06a.75.75 0 01-1.06 1.061l-1.061-1.06a.75.75 0 010-1.061zM16 8a.75.75 0 01-.75.75h-1.5a.75.75 0 010-1.5h1.5A.75.75 0 0116 8zM3 8a.75.75 0 01-.75.75H.75a.75.75 0 010-1.5h1.5A.75.75 0 013 8zm10.657-5.657a.75.75 0 010 1.061l-1.061 1.06a.75.75 0 11-1.06-1.06l1.06-1.06a.75.75 0 011.06 0zm-9.193 9.193a.75.75 0 010 1.06l-1.06 1.061a.75.75 0 11-1.061-1.06l1.06-1.061a.75.75 0 011.061 0z', 'moon': 'M9.598 1.591a.75.75 0 01.785-.175 7 7 0 11-8.967 8.967.75.75 0 01.961-.96 5.5 5.5 0 007.046-7.046.75.75 0 01.175-.786zm1.616 1.945a7 7 0 01-7.678 7.678 5.5 5.5 0 107.678-7.678z', 'sync': 'M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 0 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z', 'search': 'M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z', 'rss': 'M2.002 2.725a.75.75 0 0 1 .797-.699C8.79 2.42 13.58 7.21 13.974 13.201a.75.75 0 0 1-1.497.098 10.502 10.502 0 0 0-9.776-9.776.747.747 0 0 1-.7-.798ZM2.84 7.05h-.002a7.002 7.002 0 0 1 6.113 6.111.75.75 0 0 1-1.49.178 5.503 5.503 0 0 0-4.8-4.8.75.75 0 0 1 .179-1.489ZM2 13a1 1 0 1 1 2 0 1 1 0 0 1-2 0Z', 'upload': 'M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14Z M11.78 4.72a.749.749 0 1 1-1.06 1.06L8.75 3.811V9.5a.75.75 0 0 1-1.5 0V3.811L5.28 5.78a.749.749 0 1 1-1.06-1.06l3.25-3.25a.749.749 0 0 1 1.06 0l3.25 3.25Z', 'post': 'M0 3.75C0 2.784.784 2 1.75 2h12.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 14H1.75A1.75 1.75 0 0 1 0 12.25Zm1.75-.25a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-8.5a.25.25 0 0 0-.25-.25ZM3.5 6.25a.75.75 0 0 1 .75-.75h7a.75.75 0 0 1 0 1.5h-7a.75.75 0 0 1-.75-.75Zm.75 2.25h4a.75.75 0 0 1 0 1.5h-4a.75.75 0 0 1 0-1.5Z'};
-var utterancesLoad=0;
-
-let themeSettings={
-    "dark": ["dark","moon","#00f0ff","dark-blue"],
-    "light": ["light","sun","#ff5000","github-light"],
-    "auto": ["auto","sync","","preferred-color-scheme"]
-};
-function changeTheme(mode, icon, color, utheme){
-    document.documentElement.setAttribute("data-color-mode",mode);
-    document.getElementById("themeSwitch").setAttribute("d",value=IconList[icon]);
-    document.getElementById("themeSwitch").parentNode.style.color=color;
-    if(utterancesLoad==1){utterancesTheme(utheme);}
-}
-function modeSwitch(){
-    let currentMode=document.documentElement.getAttribute('data-color-mode');
-    let newMode = currentMode === "light" ? "dark" : currentMode === "dark" ? "auto" : "light";
-    localStorage.setItem("meek_theme", newMode);
-    if(themeSettings[newMode]){
-        changeTheme(...themeSettings[newMode]);
-    }
-}
-function utterancesTheme(theme){
-    const message={type:'set-theme',theme: theme};
-    const iframe=document.getElementsByClassName('utterances-frame')[0];
-    iframe.contentWindow.postMessage(message,'https://utteranc.es');
-}
-if(themeSettings[theme]){changeTheme(...themeSettings[theme]);}
-console.log("\n %c Gmeek last https://github.com/Meekdai/Gmeek \n","padding:5px 0;background:#02d81d;color:#fff");
-</script>
-
-<script>
-document.getElementById("pathSearch").setAttribute("d",IconList["search"]);
-document.getElementById("pathRSS").setAttribute("d",IconList["rss"]);
-iconTOP=document.getElementsByClassName("svgTop1");
-iconPost=document.getElementsByClassName("svgTop0");
-for(var i=0;i<iconTOP.length;i++){
-    iconTOP[i].setAttribute("d",IconList["upload"]);
-    iconTOP[i].parentNode.style.color="red";
-}
-for(var i=0;i<iconPost.length;i++){
-    iconPost[i].setAttribute("d",IconList["post"]);
-}
-
-
-
-
-</script>
-
-
 </html>

--- a/docs/post/pu-tong-ren-bu-shi-he-zuo-xiao-lv-shu.html
+++ b/docs/post/pu-tong-ren-bu-shi-he-zuo-xiao-lv-shu.html
@@ -1,205 +1,71 @@
 <!DOCTYPE html>
-<html data-color-mode="light" data-dark-theme="dark" data-light-theme="light" lang="zh-CN">
+<html lang="zh-CN">
 <head>
-    <meta content="text/html; charset=utf-8" http-equiv="content-type" />
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link href='https://mirrors.sustech.edu.cn/cdnjs/ajax/libs/Primer/21.0.7/primer.css' rel='stylesheet' />
-    
-    <link rel="icon" href="https://github.githubassets.com/favicons/favicon.svg"><script>
-        let theme = localStorage.getItem("meek_theme") || "light";
-        document.documentElement.setAttribute("data-color-mode", theme);
-    </script>
-<meta name="description" content="大家好  我是硬核水墨，这两个月测试了几个圈子里很火的搞钱小项目，小红书虚拟资料引流，小学生资料，教务资料，小绿书图文带货和流量主等等。">
-<meta property="og:title" content="普通人不适合做小绿书">
-<meta property="og:description" content="大家好  我是硬核水墨，这两个月测试了几个圈子里很火的搞钱小项目，小红书虚拟资料引流，小学生资料，教务资料，小绿书图文带货和流量主等等。">
-<meta property="og:type" content="article">
-<meta property="og:url" content="https://hacksmo.github.io/post/pu-tong-ren-bu-shi-he-zuo-xiao-lv-shu.html">
-<meta property="og:image" content="https://github.githubassets.com/favicons/favicon.svg">
-<title>普通人不适合做小绿书</title>
-
-
-
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>普通人不适合做小绿书 · 硬核水墨</title>
+  <meta name="description" content="水墨对小绿书项目的实战复盘，包含去重工具、执行策略与提升胜率的思考。">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css@5.5.1/github-markdown-light.min.css">
 </head>
-<style>
-body{box-sizing: border-box;min-width: 200px;max-width: 900px;margin: 20px auto;padding: 45px;font-size: 16px;font-family: sans-serif;line-height: 1.25;}
-#header{display:flex;padding-bottom:8px;border-bottom: 1px solid var(--borderColor-muted, var(--color-border-muted));margin-bottom: 16px;}
-#footer {margin-top:64px; text-align: center;font-size: small;}
-
-</style>
-
-<style>
-.postTitle{margin: auto 0;font-size:40px;font-weight:bold;}
-.title-right{display:flex;margin:auto 0 0 auto;}
-.title-right .circle{padding: 14px 16px;margin-right:8px;}
-#postBody{border-bottom: 1px solid var(--color-border-default);padding-bottom:36px;}
-#postBody hr{height:2px;}
-#cmButton{height:48px;margin-top:48px;}
-#comments{margin-top:64px;}
-.g-emoji{font-size:24px;}
-@media (max-width: 600px) {
-    body {padding: 8px;}
-    .postTitle{font-size:24px;}
-}
-
-</style>
-
-
-
-
 <body>
-    <div id="header">
-<h1 class="postTitle">普通人不适合做小绿书</h1>
-<div class="title-right">
-    <a href="https://hacksmo.github.io" id="buttonHome" class="btn btn-invisible circle" title="首页">
-        <svg class="octicon" width="16" height="16">
-            <path id="pathHome" fill-rule="evenodd"></path>
-        </svg>
-    </a>
-    
-    <a href="https://github.com/hacksmo/hacksmo.github.io/issues/2" target="_blank" class="btn btn-invisible circle" title="Issue">
-        <svg class="octicon" width="16" height="16">
-            <path id="pathIssue" fill-rule="evenodd"></path>
-        </svg>
-    </a>
-    
-
-    <a class="btn btn-invisible circle" onclick="modeSwitch();" title="切换主题">
-        <svg class="octicon" width="16" height="16" >
-            <path id="themeSwitch" fill-rule="evenodd"></path>
-        </svg>
+  <div class="container">
+    <a class="back-link" href="../index.html" aria-label="返回首页">
+      <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+      </svg>
+      返回文章列表
     </a>
 
-</div>
-</div>
-    <div id="content">
-<div class="markdown-body" id="postBody"><p>大家好  我是硬核水墨，这两个月测试了几个圈子里很火的搞钱小项目，小红书虚拟资料引流，小学生资料，教务资料，小绿书图文带货和流量主等等。</p>
-<p>这些项目门槛听起来不高，但是实操起来还是能劝退不少人的，要么就想一下子拿到结果，要么就是各种问题，卡在了 0 小眼睛，训练营给了 SOP， 但是没有使用电脑的基础，看得懂但不会操作，最后就放弃了</p>
-<p>好，先更新最多人关心的去重问题，怎么简单快速的去重</p>
-<h2>去重工具</h2>
-<h3>1、Photoshop</h3>
-<p>通过创建脚本的方式，调整高斯模糊，增加图层、描边、调整曝光对比度锐度等等来实现</p>
-<p>有视频教程，但这里放不出来，没有软件安装包的加水墨微信发你软件安装包</p>
-<h3>2、美图秀秀批处理功能</h3>
-<p>其实美图秀秀软件非常强大</p>
-<p>添加不同的滤镜，加上自己的水印，调整颜色对比度、亮度等参数就可以</p>
-<h2>去重了就能爆？</h2>
-<p>去重不难，很简单，但去重只是表面问题</p>
-<p>去重之后还需要养号，不是发了就能立马变现的，要是那么简单也不至于轮到咱们普通人来做了</p>
-<p><strong>想赚到钱的核心方法就是提升自己的胜率</strong></p>
-<p>别人注册一个账号发，那我 3 个账号？5 个账号？10 个账号行不行？是不是就比别人多 10 倍的胜率？</p>
-<p>别人一天发 1 篇，那我发 3 篇？发 5 篇？<br>
-别人找对标都随便复制粘贴，那我用 AI 稍微优化下标题和内容，不是更能吸引人？</p>
-<p>别人坚持了 3 天就放弃了，那我要是每天复盘，多多坚持复盘，多看牛人的案例，是不是就胜率上来了？</p>
-<p>这些都是能提高自己的胜率的，这也是为什么那么多人要搞矩阵号，需要注册那么多虚拟号的原因</p>
-<p>大部分人很难坚持下来的原因就是缺少一个好的环境持续的影响他</p>
-<p><strong>但是你想赚钱，但不懂这些技术咋办？</strong></p>
-<p>关注我的老粉丝都知道，水墨搞技术出身，经常研究海内外这些小项目，从初中就开始帮人修电脑赚钱了</p>
-<p>前段时间搞的香港开户交流群，帮不少群友成功下卡。</p>
-<p>正好我有这技术这一块的经验，同时也经常折腾类似的项目，也想带大家一起搞项目，创建了一个小绿书搞钱陪伴群，原价 199 的陪伴群，限时 19.9，扫码加水墨微信直接转账拉你入群</p>
-<p>群交付内容：带新人从 0 到 1 答疑解惑，比如怎么找爆款对标，找到爆款怎么去重，发了好几条小眼睛都是 0 怎么办， 流量主怎么快速开通等等各种问题</p>
-<p>关注水墨，一起成长研究搞钱，过上稳稳的幸福生活。</p>
-<p>微信：youxiumo  公众号：硬核水墨</p></div>
-<div style="font-size:small;margin-top:8px;float:right;"></div>
+    <header class="article-header">
+      <h1 class="article-title">普通人不适合做小绿书</h1>
+      <div class="article-meta">
+        <time datetime="2024-11-12">2024 年 11 月 12 日</time>
+        <span class="tag-chip">documentation</span>
+      </div>
+    </header>
 
-<button class="btn btn-block" type="button" onclick="openComments()" id="cmButton">评论</button>
-<div class="comments" id="comments"></div>
+    <article class="article-wrapper">
+      <div class="markdown-body">
+        <p>大家好  我是硬核水墨，这两个月测试了几个圈子里很火的搞钱小项目，小红书虚拟资料引流，小学生资料，教务资料，小绿书图文带货和流量主等等。</p>
+        <p>这些项目门槛听起来不高，但是实操起来还是能劝退不少人的，要么就想一下子拿到结果，要么就是各种问题，卡在了 0 小眼睛，训练营给了 SOP， 但是没有使用电脑的基础，看得懂但不会操作，最后就放弃了</p>
+        <p>好，先更新最多人关心的去重问题，怎么简单快速的去重</p>
+        <h2>去重工具</h2>
+        <h3>1、Photoshop</h3>
+        <p>通过创建脚本的方式，调整高斯模糊，增加图层描边、调整曝光对比度锐度等等来实现</p>
+        <p>有视频教程，但这里放不出来，没有软件安装包的加水墨微信发你软件安装包</p>
+        <h3>2、美图秀秀批处理功能</h3>
+        <p>其实美图秀秀软件非常强大</p>
+        <p>添加不同的滤镜，加上自己的水印，调整颜色对比度、亮度等参数就可以</p>
+        <h2>去重了就能爆？</h2>
+        <p>去重不难，很简单，但去重只是表面问题</p>
+        <p>去重之后还需要养号，不是发了就能立马变现的，要是那么简单也不至于轮到咱们普通人来做了</p>
+        <p><strong>想赚到钱的核心方法就是提升自己的胜率</strong></p>
+        <p>别人注册一个账号发，那我 3 个账号？5 个账号？10 个账号行不行？是不是就比别人多 10 倍的胜率？</p>
+        <p>别人一天发 1 篇，那我发 3 篇？发 5 篇？<br>别人找对标都随便复制粘贴，那我用 AI 稍微优化下标题和内容，不是更能吸引人？</p>
+        <p>别人坚持了 3 天就放弃了，那我要是每天复盘，多多坚持复盘，多看牛人的案例，是不是就胜率上来了？</p>
+        <p>这些都是能提高自己的胜率的，这也是为什么那么多人要搞矩阵号，需要注册那么多虚拟号的原因</p>
+        <p>大部分人很难坚持下来的原因就是缺少一个好的环境持续的影响他</p>
+        <p><strong>但是你想赚钱，但不懂这些技术咋办？</strong></p>
+        <p>关注我的老粉丝都知道，水墨搞技术出身，经常研究海内外这些小项目，从初中就开始帮人修电脑赚钱了</p>
+        <p>前段时间搞的香港开户交流群，帮不少群友成功下卡。</p>
+        <p>正好我有这技术这一块的经验，同时也经常折腾类似的项目，也想带大家一起搞项目，创建了一个小绿书搞钱陪伴群，原价 199 的陪伴群，限时 19.9，扫码加水墨微信直接转账拉你入群</p>
+        <p>群交付内容：带新人从 0 到 1 答疑解惑，比如怎么找爆款对标，找到爆款怎么去重，发了好几条小眼睛都是 0 怎么办， 流量主怎么快速开通等等各种问题</p>
+        <p>关注水墨，一起成长研究搞钱，过上稳稳的幸福生活。</p>
+        <p>微信：youxiumo  公众号：硬核水墨</p>
+      </div>
+    </article>
 
-</div>
-    <div id="footer"><div id="footer1">Copyright © <span id="copyrightYear"></span> <a href="https://hacksmo.github.io">硬核水墨</a></div>
-<div id="footer2">
-    <span id="runday"></span><span>Powered by <a href="https://meekdai.com/Gmeek.html" target="_blank">Gmeek</a></span>
-</div>
+    <footer class="site-footer">
+      <p>© <span id="year"></span> 硬核水墨 · 感谢阅读</p>
+    </footer>
+  </div>
 
-<script>
-var now=new Date();
-document.getElementById("copyrightYear").innerHTML=now.getFullYear();
-
-if(""!=""){
-    var startSite=new Date("");
-    var diff=now.getTime()-startSite.getTime();
-    var diffDay=Math.floor(diff/(1000*60*60*24));
-    document.getElementById("runday").innerHTML="网站运行"+diffDay+"天"+" • ";
-}
-</script></div>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
 </body>
-<script>
-var IconList={'sun': 'M8 10.5a2.5 2.5 0 100-5 2.5 2.5 0 000 5zM8 12a4 4 0 100-8 4 4 0 000 8zM8 0a.75.75 0 01.75.75v1.5a.75.75 0 01-1.5 0V.75A.75.75 0 018 0zm0 13a.75.75 0 01.75.75v1.5a.75.75 0 01-1.5 0v-1.5A.75.75 0 018 13zM2.343 2.343a.75.75 0 011.061 0l1.06 1.061a.75.75 0 01-1.06 1.06l-1.06-1.06a.75.75 0 010-1.06zm9.193 9.193a.75.75 0 011.06 0l1.061 1.06a.75.75 0 01-1.06 1.061l-1.061-1.06a.75.75 0 010-1.061zM16 8a.75.75 0 01-.75.75h-1.5a.75.75 0 010-1.5h1.5A.75.75 0 0116 8zM3 8a.75.75 0 01-.75.75H.75a.75.75 0 010-1.5h1.5A.75.75 0 013 8zm10.657-5.657a.75.75 0 010 1.061l-1.061 1.06a.75.75 0 11-1.06-1.06l1.06-1.06a.75.75 0 011.06 0zm-9.193 9.193a.75.75 0 010 1.06l-1.06 1.061a.75.75 0 11-1.061-1.06l1.06-1.061a.75.75 0 011.061 0z', 'moon': 'M9.598 1.591a.75.75 0 01.785-.175 7 7 0 11-8.967 8.967.75.75 0 01.961-.96 5.5 5.5 0 007.046-7.046.75.75 0 01.175-.786zm1.616 1.945a7 7 0 01-7.678 7.678 5.5 5.5 0 107.678-7.678z', 'sync': 'M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 0 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z', 'home': 'M6.906.664a1.749 1.749 0 0 1 2.187 0l5.25 4.2c.415.332.657.835.657 1.367v7.019A1.75 1.75 0 0 1 13.25 15h-3.5a.75.75 0 0 1-.75-.75V9H7v5.25a.75.75 0 0 1-.75.75h-3.5A1.75 1.75 0 0 1 1 13.25V6.23c0-.531.242-1.034.657-1.366l5.25-4.2Zm1.25 1.171a.25.25 0 0 0-.312 0l-5.25 4.2a.25.25 0 0 0-.094.196v7.019c0 .138.112.25.25.25H5.5V8.25a.75.75 0 0 1 .75-.75h3.5a.75.75 0 0 1 .75.75v5.25h2.75a.25.25 0 0 0 .25-.25V6.23a.25.25 0 0 0-.094-.195Z', 'github': 'M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z'};
-var utterancesLoad=0;
-
-let themeSettings={
-    "dark": ["dark","moon","#00f0ff","dark-blue"],
-    "light": ["light","sun","#ff5000","github-light"],
-    "auto": ["auto","sync","","preferred-color-scheme"]
-};
-function changeTheme(mode, icon, color, utheme){
-    document.documentElement.setAttribute("data-color-mode",mode);
-    document.getElementById("themeSwitch").setAttribute("d",value=IconList[icon]);
-    document.getElementById("themeSwitch").parentNode.style.color=color;
-    if(utterancesLoad==1){utterancesTheme(utheme);}
-}
-function modeSwitch(){
-    let currentMode=document.documentElement.getAttribute('data-color-mode');
-    let newMode = currentMode === "light" ? "dark" : currentMode === "dark" ? "auto" : "light";
-    localStorage.setItem("meek_theme", newMode);
-    if(themeSettings[newMode]){
-        changeTheme(...themeSettings[newMode]);
-    }
-}
-function utterancesTheme(theme){
-    const message={type:'set-theme',theme: theme};
-    const iframe=document.getElementsByClassName('utterances-frame')[0];
-    iframe.contentWindow.postMessage(message,'https://utteranc.es');
-}
-if(themeSettings[theme]){changeTheme(...themeSettings[theme]);}
-console.log("\n %c Gmeek last https://github.com/Meekdai/Gmeek \n","padding:5px 0;background:#02d81d;color:#fff");
-</script>
-
-<script>
-document.getElementById("pathHome").setAttribute("d",IconList["home"]);
-document.getElementById("pathIssue").setAttribute("d",IconList["github"]);
-
-
-
-function openComments(){
-    cm=document.getElementById("comments");
-    cmButton=document.getElementById("cmButton");
-    cmButton.innerHTML="loading";
-    span=document.createElement("span");
-    span.setAttribute("class","AnimatedEllipsis");
-    cmButton.appendChild(span);
-
-    script=document.createElement("script");
-    script.setAttribute("src","https://utteranc.es/client.js");
-    script.setAttribute("repo","hacksmo/hacksmo.github.io");
-    script.setAttribute("issue-term","title");
-    
-    if(localStorage.getItem("meek_theme")=="dark"){script.setAttribute("theme","dark-blue");}
-    else if(localStorage.getItem("meek_theme")=="light") {script.setAttribute("theme","github-light");}
-    else{script.setAttribute("theme","preferred-color-scheme");}
-    
-    script.setAttribute("crossorigin","anonymous");
-    script.setAttribute("async","");
-    cm.appendChild(script);
-
-    int=self.setInterval("iFrameLoading()",200);
-}
-
-function iFrameLoading(){
-    var utterances=document.getElementsByClassName('utterances');
-    if(utterances.length==1){
-        if(utterances[0].style.height!=""){
-            utterancesLoad=1;
-            int=window.clearInterval(int);
-            document.getElementById("cmButton").style.display="none";
-            console.log("utterances Load OK");
-        }
-    }
-}
-
-
-
-</script>
-
-
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,271 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f8fb;
+  --card-bg: #ffffff;
+  --text: #1f2933;
+  --muted: #6b7280;
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.1);
+  --border: #e2e8f0;
+  --code-bg: #f0f4ff;
+  font-family: 'Inter', 'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.08), transparent 55%),
+              radial-gradient(circle at bottom right, rgba(14, 116, 144, 0.08), transparent 45%),
+              var(--bg);
+  color: var(--text);
+  line-height: 1.7;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--accent);
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 1.5rem 4rem;
+}
+
+.site-header {
+  padding: 4rem 0 2rem;
+  text-align: center;
+}
+
+.site-title {
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  margin: 0 0 0.5rem;
+}
+
+.site-description {
+  margin: 0 auto;
+  max-width: 560px;
+  font-size: 1.05rem;
+  color: var(--muted);
+}
+
+.site-links {
+  margin-top: 1.75rem;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  font-weight: 500;
+}
+
+.site-links a {
+  color: var(--accent);
+}
+
+main {
+  margin-top: 2.5rem;
+}
+
+.post-list {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.post-card {
+  background: var(--card-bg);
+  border-radius: 18px;
+  padding: 1.75rem 1.85rem;
+  border: 1px solid rgba(37, 99, 235, 0.08);
+  box-shadow: 0 18px 45px -30px rgba(37, 99, 235, 0.4);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.post-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 24px 60px -28px rgba(15, 23, 42, 0.25);
+}
+
+.post-card time {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.post-card h2 {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin: 0.6rem 0 0.75rem;
+}
+
+.post-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.tag-chip::before {
+  content: "#";
+  font-weight: 600;
+}
+
+.site-footer {
+  text-align: center;
+  padding: 3rem 0 2rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.article-header {
+  padding: 3rem 0 1.5rem;
+  text-align: center;
+}
+
+.article-title {
+  margin: 0;
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  font-weight: 700;
+}
+
+.article-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+  color: var(--muted);
+}
+
+.article-wrapper {
+  background: var(--card-bg);
+  border-radius: 24px;
+  padding: clamp(1.5rem, 4vw, 3.25rem);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: 0 20px 50px -30px rgba(30, 64, 175, 0.35);
+}
+
+.markdown-body {
+  font-size: 1.05rem;
+  color: var(--text);
+}
+
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4 {
+  margin-top: 2.5rem;
+  color: #111827;
+}
+
+.markdown-body pre,
+.markdown-body code {
+  background: var(--code-bg);
+  border-radius: 8px;
+}
+
+.markdown-body pre {
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+.markdown-body blockquote {
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  border-left: 4px solid rgba(37, 99, 235, 0.5);
+  background: rgba(37, 99, 235, 0.08);
+  color: #0f172a;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+  font-weight: 500;
+  color: var(--accent);
+}
+
+.back-link svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.tag-page {
+  display: grid;
+  gap: 2rem;
+}
+
+.tag-section {
+  background: var(--card-bg);
+  padding: 1.5rem 1.75rem;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 16px 45px -28px rgba(15, 23, 42, 0.25);
+}
+
+.tag-section h2 {
+  margin: 0 0 1rem;
+  font-size: 1.4rem;
+}
+
+.tag-section ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.tag-section li a {
+  display: flex;
+  justify-content: space-between;
+  color: var(--text);
+  font-weight: 500;
+}
+
+.tag-section li span {
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  .container {
+    padding: 0 1.25rem 3rem;
+  }
+
+  .site-header {
+    padding: 3rem 0 1.5rem;
+  }
+
+  .post-card {
+    padding: 1.5rem;
+  }
+
+  .article-wrapper {
+    border-radius: 18px;
+    padding: 1.5rem;
+  }
+}

--- a/docs/tag.html
+++ b/docs/tag.html
@@ -1,285 +1,100 @@
 <!DOCTYPE html>
-<html data-color-mode="light" data-dark-theme="dark" data-light-theme="light" lang="zh-CN">
+<html lang="zh-CN">
 <head>
-    <meta content="text/html; charset=utf-8" http-equiv="content-type" />
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link href='https://mirrors.sustech.edu.cn/cdnjs/ajax/libs/Primer/21.0.7/primer.css' rel='stylesheet' />
-    
-    <link rel="icon" href="https://github.githubassets.com/favicons/favicon.svg"><script>
-        let theme = localStorage.getItem("meek_theme") || "light";
-        document.documentElement.setAttribute("data-color-mode", theme);
-    </script>
-<meta name="description" content="硬核水墨 search page">
-<title>硬核水墨 - Tag</title>
-
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>标签索引 · 硬核水墨</title>
+  <meta name="description" content="硬核水墨的 Markdown 文章标签索引，按主题快速查找内容。">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
 </head>
-<style>
-body{box-sizing: border-box;min-width: 200px;max-width: 900px;margin: 20px auto;padding: 45px;font-size: 16px;font-family: sans-serif;line-height: 1.25;}
-#header{display:flex;padding-bottom:8px;border-bottom: 1px solid var(--borderColor-muted, var(--color-border-muted));margin-bottom: 16px;}
-#footer {margin-top:64px; text-align: center;font-size: small;}
-
-</style>
-
-<style>
-.tagTitle{margin:auto 0;font-size:40px;font-weight:bold;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;}
-.title-right{display:flex;margin:auto 0 0 auto;}
-.title-right .circle{padding: 14px 16px;margin-right:8px;}
-
-.subnav-search{width:222px;margin-top:8px;margin-right:8px;}
-.subnav-search-input{width:160px;border-top-right-radius:0px;border-bottom-right-radius:0px;}
-.subnav-search button{padding:5px 8px;border-top-left-radius:0px;border-bottom-left-radius:0px;}
-
-.SideNav-icon{margin-right:16px}
-.Label{color: #fff;margin-left:4px;}
-#taglabel .Label {margin-bottom:8px;}
-.Counter{color:#fff;background-color:rgba(234, 238, 242, 0.5)}
-
-.genTime{float: right;}
-.d-flex{min-width:0;}
-.listTitle{overflow:hidden;white-space:nowrap;text-overflow: ellipsis;max-width: 100%;}
-.listLabels{white-space:nowrap;}
-
-@media (max-width: 600px) {
-    body { padding: 8px;}
-    .tagTitle{display:none;}
-    .LabelTime{display:none;}
-}
-</style>
-
-
 <body>
-    <div id="header">
-<span class="tagTitle"><span>Loading</span><span class="AnimatedEllipsis"></span></span>
-<div class="title-right">
-    <div class="subnav-search">
-        <input type="search" class="form-control subnav-search-input float-left" aria-label="Search site" value="" style="height:32px;">
-        <button class="btn float-left" type="submit" onclick="javascript:searchShow()">搜索</button>
-        <svg class="subnav-search-icon octicon octicon-search" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
-            <path id="searchSVG" fill-rule="evenodd"></path>
-        </svg>
-    </div>
-    <a href="https://hacksmo.github.io" id="buttonHome" class="btn btn-invisible circle" title="首页">
-        <svg class="octicon" width="16" height="16">
-            <path id="pathHome" fill-rule="evenodd"></path>
-        </svg>
+  <div class="container">
+    <a class="back-link" href="index.html" aria-label="返回首页">
+      <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+      </svg>
+      返回文章列表
     </a>
-    <a class="btn btn-invisible circle" onclick="modeSwitch()" title="切换主题">
-        <svg class="octicon" width="16" height="16" >
-            <path id="themeSwitch" fill-rule="evenodd"></path>
-        </svg>
-    </a>
-</div>
-</div>
-    <div id="content">
-<div id="taglabel" style="margin-bottom:8px;"></div>
-<nav class="SideNav"></nav>
-<div class="notFind" style="display:none;font-size:24px;margin:8px;">Not Find</div>
-</div>
-    <div id="footer"><div id="footer1">Copyright © <span id="copyrightYear"></span> <a href="https://hacksmo.github.io">硬核水墨</a></div>
-<div id="footer2">
-    <span id="runday"></span><span>Powered by <a href="https://meekdai.com/Gmeek.html" target="_blank">Gmeek</a></span>
-</div>
 
-<script>
-var now=new Date();
-document.getElementById("copyrightYear").innerHTML=now.getFullYear();
+    <header class="site-header" style="padding-top: 2.5rem; padding-bottom: 1.5rem;">
+      <h1 class="site-title">标签索引</h1>
+      <p class="site-description">按主题浏览文章，快速找到你感兴趣的 Markdown 内容。</p>
+    </header>
 
-if(""!=""){
-    var startSite=new Date("");
-    var diff=now.getTime()-startSite.getTime();
-    var diffDay=Math.floor(diff/(1000*60*60*24));
-    document.getElementById("runday").innerHTML="网站运行"+diffDay+"天"+" • ";
-}
-</script></div>
+    <main>
+      <section class="tag-page" id="tagPage" aria-live="polite"></section>
+    </main>
+
+    <footer class="site-footer">
+      <p>© <span id="year"></span> 硬核水墨</p>
+    </footer>
+  </div>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+
+    fetch('postList.json')
+      .then((response) => response.json())
+      .then((data) => {
+        const tagMap = new Map();
+
+        Object.values(data)
+          .filter((item) => item && item.postUrl)
+          .forEach((post) => {
+            const entry = {
+              title: post.postTitle,
+              url: post.postUrl,
+              date: post.createdDate
+            };
+
+            (post.labels || ['未分类']).forEach((label) => {
+              if (!tagMap.has(label)) {
+                tagMap.set(label, []);
+              }
+              tagMap.get(label).push(entry);
+            });
+          });
+
+        const tagPage = document.getElementById('tagPage');
+
+        if (tagMap.size === 0) {
+          tagPage.innerHTML = '<p style="color: var(--muted);">暂无标签内容。</p>';
+          return;
+        }
+
+        const sortedTags = Array.from(tagMap.entries()).sort((a, b) => b[1].length - a[1].length);
+
+        for (const [tag, posts] of sortedTags) {
+          const section = document.createElement('section');
+          section.className = 'tag-section';
+          const count = posts.length;
+
+          const listItems = posts
+            .sort((a, b) => new Date(b.date) - new Date(a.date))
+            .map((post) => {
+              const date = new Date(`${post.date}T00:00:00`).toLocaleDateString('zh-CN', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric'
+              });
+              return `<li><a href="${post.url}">${post.title}<span>${date}</span></a></li>`;
+            })
+            .join('');
+
+          section.innerHTML = `
+            <h2>${tag} <span style="color: var(--muted); font-size: 0.9rem;">(${count})</span></h2>
+            <ul>${listItems}</ul>
+          `;
+
+          tagPage.appendChild(section);
+        }
+      })
+      .catch(() => {
+        document.getElementById('tagPage').innerHTML = '<p style="color: var(--muted);">标签数据加载失败，请稍后再试。</p>';
+      });
+  </script>
 </body>
-<script>
-var IconList={'sun': 'M8 10.5a2.5 2.5 0 100-5 2.5 2.5 0 000 5zM8 12a4 4 0 100-8 4 4 0 000 8zM8 0a.75.75 0 01.75.75v1.5a.75.75 0 01-1.5 0V.75A.75.75 0 018 0zm0 13a.75.75 0 01.75.75v1.5a.75.75 0 01-1.5 0v-1.5A.75.75 0 018 13zM2.343 2.343a.75.75 0 011.061 0l1.06 1.061a.75.75 0 01-1.06 1.06l-1.06-1.06a.75.75 0 010-1.06zm9.193 9.193a.75.75 0 011.06 0l1.061 1.06a.75.75 0 01-1.06 1.061l-1.061-1.06a.75.75 0 010-1.061zM16 8a.75.75 0 01-.75.75h-1.5a.75.75 0 010-1.5h1.5A.75.75 0 0116 8zM3 8a.75.75 0 01-.75.75H.75a.75.75 0 010-1.5h1.5A.75.75 0 013 8zm10.657-5.657a.75.75 0 010 1.061l-1.061 1.06a.75.75 0 11-1.06-1.06l1.06-1.06a.75.75 0 011.06 0zm-9.193 9.193a.75.75 0 010 1.06l-1.06 1.061a.75.75 0 11-1.061-1.06l1.06-1.061a.75.75 0 011.061 0z', 'moon': 'M9.598 1.591a.75.75 0 01.785-.175 7 7 0 11-8.967 8.967.75.75 0 01.961-.96 5.5 5.5 0 007.046-7.046.75.75 0 01.175-.786zm1.616 1.945a7 7 0 01-7.678 7.678 5.5 5.5 0 107.678-7.678z', 'sync': 'M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 0 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z', 'home': 'M6.906.664a1.749 1.749 0 0 1 2.187 0l5.25 4.2c.415.332.657.835.657 1.367v7.019A1.75 1.75 0 0 1 13.25 15h-3.5a.75.75 0 0 1-.75-.75V9H7v5.25a.75.75 0 0 1-.75.75h-3.5A1.75 1.75 0 0 1 1 13.25V6.23c0-.531.242-1.034.657-1.366l5.25-4.2Zm1.25 1.171a.25.25 0 0 0-.312 0l-5.25 4.2a.25.25 0 0 0-.094.196v7.019c0 .138.112.25.25.25H5.5V8.25a.75.75 0 0 1 .75-.75h3.5a.75.75 0 0 1 .75.75v5.25h2.75a.25.25 0 0 0 .25-.25V6.23a.25.25 0 0 0-.094-.195Z', 'search': 'M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z', 'post': 'M0 3.75C0 2.784.784 2 1.75 2h12.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 14H1.75A1.75 1.75 0 0 1 0 12.25Zm1.75-.25a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-8.5a.25.25 0 0 0-.25-.25ZM3.5 6.25a.75.75 0 0 1 .75-.75h7a.75.75 0 0 1 0 1.5h-7a.75.75 0 0 1-.75-.75Zm.75 2.25h4a.75.75 0 0 1 0 1.5h-4a.75.75 0 0 1 0-1.5Z'};
-var utterancesLoad=0;
-
-let themeSettings={
-    "dark": ["dark","moon","#00f0ff","dark-blue"],
-    "light": ["light","sun","#ff5000","github-light"],
-    "auto": ["auto","sync","","preferred-color-scheme"]
-};
-function changeTheme(mode, icon, color, utheme){
-    document.documentElement.setAttribute("data-color-mode",mode);
-    document.getElementById("themeSwitch").setAttribute("d",value=IconList[icon]);
-    document.getElementById("themeSwitch").parentNode.style.color=color;
-    if(utterancesLoad==1){utterancesTheme(utheme);}
-}
-function modeSwitch(){
-    let currentMode=document.documentElement.getAttribute('data-color-mode');
-    let newMode = currentMode === "light" ? "dark" : currentMode === "dark" ? "auto" : "light";
-    localStorage.setItem("meek_theme", newMode);
-    if(themeSettings[newMode]){
-        changeTheme(...themeSettings[newMode]);
-    }
-}
-function utterancesTheme(theme){
-    const message={type:'set-theme',theme: theme};
-    const iframe=document.getElementsByClassName('utterances-frame')[0];
-    iframe.contentWindow.postMessage(message,'https://utteranc.es');
-}
-if(themeSettings[theme]){changeTheme(...themeSettings[theme]);}
-console.log("\n %c Gmeek last https://github.com/Meekdai/Gmeek \n","padding:5px 0;background:#02d81d;color:#fff");
-</script>
-
-<script>
-document.getElementById("pathHome").setAttribute("d",IconList["home"]);
-document.getElementById("searchSVG").setAttribute("d",IconList["search"]);
-
-tagList=[];
-labelsCount={};
-jsonData='';
-let requestJson="postList.json"
-let request=new XMLHttpRequest();
-request.open("GET",requestJson);
-request.responseType='text';
-request.send();
-request.onload=function(){
-    jsonData=JSON.parse(request.response);
-    console.log(jsonData);
-    showList(labelsCount);
-    setClassDisplay(decodeURI(window.location.hash.slice(1)));
-}
-
-function showList(labelsCount){
-    let SideNav=document.getElementsByClassName("SideNav")[0];
-    SideNav.classList.add("border");
-    let taglabel=document.getElementById("taglabel");
-
-    jsonData['labelColorDict']["All"]="#000";
-    labelsCount["All"]=0;
-    for (let key in jsonData) {
-        if (key !== 'labelColorDict' && Array.isArray(jsonData[key]['labels'])) {
-            labelsCount["All"]++;
-            for (let label of jsonData[key]['labels']) {
-                labelsCount[label] = (labelsCount[label] || 0) + 1;
-            }
-        }
-    }
-
-    let sortedLabelsList = Object.keys(labelsCount).sort((a, b) => labelsCount[b] - labelsCount[a]);
-    for (let label of sortedLabelsList) {
-        tagList.push(label);
-        let showLabels = document.createElement("button");
-        showLabels.setAttribute("class", "Label");
-        showLabels.setAttribute("style", "background-color:" + jsonData['labelColorDict'][label]+";padding:4px;");
-        showLabels.innerHTML="&nbsp;&nbsp;"+label+" ";
-        showLabels.setAttribute("onclick", "javascript:updateShowTag('" + label + "');");
-
-        let LabelNum=document.createElement("span");
-        LabelNum.setAttribute("class","Counter");
-        LabelNum.innerHTML=labelsCount[label];
-        showLabels.appendChild(LabelNum);
-        taglabel.appendChild(showLabels);
-    }
-
-    for(i in jsonData){
-        if(i!='labelColorDict'){
-            let div=document.createElement("div");
-            div.setAttribute("class","lists "+jsonData[i]['labels'].join(" "));
-            let item=document.createElement("a");
-            item.setAttribute("class","SideNav-item d-flex flex-items-center flex-justify-between");
-            item.setAttribute("href",jsonData[i]['postUrl']);
-
-            let center=document.createElement("div");
-            center.setAttribute("class","d-flex flex-items-center");
-
-            svg=document.createElementNS('http://www.w3.org/2000/svg','svg');
-            path=document.createElementNS("http://www.w3.org/2000/svg","path"); 
-            span=document.createElement("span");
-            svg.setAttributeNS(null,"class","SideNav-icon octicon");
-            svg.setAttributeNS(null,"style","width:16px;height:16px");
-            path.setAttributeNS(null, "d", IconList["post"]);
-            svg.appendChild(path);
-
-            let title=document.createElement("span");
-            title.setAttribute("class","listTitle");
-            title.innerHTML=jsonData[i]['postTitle'];
-            center.appendChild(svg);
-            center.appendChild(title);
-
-            let listLabels=document.createElement("div");
-            listLabels.setAttribute("class","listLabels");
-            
-            for(label of jsonData[i]['labels']){
-                let LabelName=document.createElement("span");
-                LabelName.setAttribute("class","Label LabelName");
-                LabelName.setAttribute("style","background-color:"+jsonData['labelColorDict'][label]);
-                LabelName.innerHTML=label;
-                listLabels.appendChild(LabelName);
-            }
-            let LabelTime=document.createElement("span");
-            LabelTime.setAttribute("class","Label LabelTime");
-            LabelTime.setAttribute("style","background-color:"+jsonData[i]['dateLabelColor']);
-            LabelTime.innerHTML=jsonData[i]['createdDate'];
-            listLabels.appendChild(LabelTime);
-
-            item.appendChild(center);
-            item.appendChild(listLabels);
-            div.appendChild(item);
-            SideNav.appendChild(div);
-        }
-    }
-}
-
-function updateShowTag(label){
-    if(window.location.hash.slice(1)!=encodeURI(label)){
-        window.location.hash="#"+(label);
-        setClassDisplay(label);
-    }
-}
-
-function setClassDisplay(label){
-    let lists = document.getElementsByClassName("lists");
-    let tagTitle = document.getElementsByClassName("tagTitle")[0];
-    tagTitle.innerHTML="Tag #"+label;
-    document.title=label+" - 硬核水墨";
-    document.getElementsByClassName("subnav-search-input")[0].value='';
-    if(label=="All"){
-        for(let i = 0; i < lists.length; i++){lists[i].style.display='block';}
-        document.getElementsByClassName("notFind")[0].style.display='none';
-    }
-    else if(tagList.indexOf(label)!=-1){
-        for(let i = 0; i < lists.length; i++){
-            lists[i].style.display='none';
-        }
-
-        let labels = document.getElementsByClassName(label);
-        for(let i = 0; i < labels.length; i++){
-            labels[i].style.display='block';
-        }
-        document.getElementsByClassName("notFind")[0].style.display='none';
-    }
-    else{
-        document.getElementsByClassName("subnav-search-input")[0].value=label;
-        searchShow();
-    }
-}
-
-function searchShow(){
-    let lists = document.getElementsByClassName("lists");
-    let tagTitle = document.getElementsByClassName("tagTitle")[0];
-    let searchInput = document.getElementsByClassName("subnav-search-input")[0].value;
-    tagTitle.innerHTML="Search #"+searchInput;
-    if(searchInput==''){document.title="Search - 硬核水墨";}
-    else{document.title=searchInput+" - 硬核水墨";}
-    let a=0;
-    window.location.hash="#"+(searchInput);
-    for(let i = 0; i < lists.length; i++){
-        if(lists[i].childNodes[0].childNodes[0].childNodes[1].innerHTML.toUpperCase().indexOf(searchInput.toUpperCase())==-1){lists[i].style.display='none';}
-        else{lists[i].style.display='block';a=a+1;}
-    }
-    if(a==0){
-        let notFind=document.getElementsByClassName("notFind")[0];
-        notFind.style.display='block';
-        notFind.innerHTML='Not Find "'+searchInput+'"';
-    }
-    else{document.getElementsByClassName("notFind")[0].style.display='none';}
-}
-
-</script>
-
 </html>


### PR DESCRIPTION
## Summary
- replace the Gmeek-generated layout with a bespoke, minimal landing page that highlights Markdown posts
- restyle individual articles and tag index using a shared modern stylesheet and typography
- add a lightweight tag browser and shared visual language across the site

## Testing
- Not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d95427bd98832ab6737f303475a1cb